### PR TITLE
Add Pawn Promotion Backend and fix bugs with Move To String

### DIFF
--- a/src/com/chess/Game/ChessBoard.java
+++ b/src/com/chess/Game/ChessBoard.java
@@ -135,6 +135,11 @@ public class ChessBoard {
         if (move.isCapture()) {
             setPosition(move.capture, null);
         }
+        NamedColor color = p.getColor();
+        int player = p.getPlayer();
+        p = move.getPromoteTo() == null ? p : move.getPromoteTo();
+        p.setColor(color);
+        p.setPlayer(player);
         setPosition(move.getTo(), p);
         p.onMove(move);
         if (move.getOtherMove() != null) {

--- a/src/com/chess/Game/Move.java
+++ b/src/com/chess/Game/Move.java
@@ -1,5 +1,8 @@
 package com.chess.Game;
 
+import com.chess.Game.Pieces.Piece;
+import com.chess.Game.Pieces.PieceFactory;
+
 import java.security.InvalidParameterException;
 
 public class Move{
@@ -7,10 +10,27 @@ public class Move{
     private Coordinate to;
     Coordinate capture;
     private Move otherMove;
+    private Piece promoteTo;
 
     public Move(String move) {
         if (move == null) {
             throw new InvalidParameterException("move cannot be null");
+        }
+        String[] byPromote = move.split(":\\+");
+        if (byPromote.length > 1) {
+            String[] byOther = byPromote[1].split(":-");
+            this.promoteTo = PieceFactory.buildPiece(byOther[0]);
+            if (byOther.length > 1) {
+                this.otherMove = new Move(byOther[1]);
+            }
+            move = byPromote[0];
+        } else {
+            String[] byOther = byPromote[0].split(":-");
+            if (byOther.length > 1) {
+                this.otherMove = new Move(byOther[1]);
+                System.out.println(byOther[1]);
+            }
+            move = byOther[0];
         }
         if (move.startsWith("Capture ")) {
             String cap = move.split(":")[0].substring(8);
@@ -32,9 +52,6 @@ public class Move{
 
     public Move(Coordinate from, Coordinate to) {
         this(from, to, null, null);
-        this.from = from;
-        this.to = to;
-        this.capture = null;
     }
 
     public Move(Coordinate from, Coordinate to, Coordinate capture) {
@@ -42,10 +59,15 @@ public class Move{
     }
 
     public Move(Coordinate from, Coordinate to, Coordinate capture, Move otherMove) {
+        this(from, to, capture, otherMove, null);
+    }
+
+    private Move(Coordinate from, Coordinate to, Coordinate capture, Move otherMove, Piece promoteTo) {
         this.from = from;
         this.to = to;
         this.capture = capture;
         this.otherMove = otherMove;
+        this.promoteTo = promoteTo;
     }
 
     public Coordinate getFrom() {
@@ -62,9 +84,13 @@ public class Move{
 
     public boolean isCapture() { return capture != null; }
 
+    public Piece getPromoteTo() {
+        return this.promoteTo;
+    }
+
     @Override
     public String toString() {
-        return (isCapture() ? "Capture " + capture + ": " : "Move: ") + from + " -> " + to;
+        return (isCapture() ? "Capture " + capture + ": " : "Move: ") + from + " -> " + to + (promoteTo != null ? ":+" + promoteTo.toString() : "") + (otherMove != null ? ":-" + otherMove.toString() : "");
     }
 
     @Override
@@ -77,10 +103,14 @@ public class Move{
     }
 
     public Move flip() {
-        return new Move(getFrom().flip(), getTo().flip(), capture == null ? null : capture.flip());
+        return new Move(getFrom().flip(), getTo().flip(), capture == null ? null : capture.flip(), otherMove == null ? null : otherMove.flip(), promoteTo);
     }
 
     public Move getOtherMove() {
         return otherMove;
+    }
+
+    public Move withPromotion(Piece promoteTo) {
+        return new Move(getFrom(), getTo(), getCapture(), getOtherMove(), promoteTo);
     }
 }

--- a/src/com/chess/Game/Pieces/Bishop.java
+++ b/src/com/chess/Game/Pieces/Bishop.java
@@ -60,6 +60,11 @@ public class Bishop extends Piece {
     }
 
     @Override
+    protected String getName() {
+        return "Bishop";
+    }
+
+    @Override
     public Piece clone() {
         return new Bishop(color, player, hasMoved);
     }

--- a/src/com/chess/Game/Pieces/CheckersPiece.java
+++ b/src/com/chess/Game/Pieces/CheckersPiece.java
@@ -61,6 +61,11 @@ public class CheckersPiece extends Piece {
     }
 
     @Override
+    protected String getName() {
+        return "Checkers Piece";
+    }
+
+    @Override
     public Piece clone() {
         return new CheckersPiece(color, player, hasMoved);
     }

--- a/src/com/chess/Game/Pieces/King.java
+++ b/src/com/chess/Game/Pieces/King.java
@@ -101,6 +101,11 @@ public class King extends Piece {
     }
 
     @Override
+    protected String getName() {
+        return "King";
+    }
+
+    @Override
     public Piece clone() {
         return new King(color, player, hasMoved);
     }

--- a/src/com/chess/Game/Pieces/Knight.java
+++ b/src/com/chess/Game/Pieces/Knight.java
@@ -51,6 +51,11 @@ public class Knight extends Piece {
     }
 
     @Override
+    protected String getName() {
+        return "Knight";
+    }
+
+    @Override
     public Piece clone() {
         return new Knight(color, player, hasMoved);
     }

--- a/src/com/chess/Game/Pieces/Pawn.java
+++ b/src/com/chess/Game/Pieces/Pawn.java
@@ -103,7 +103,19 @@ public class Pawn extends Piece {
         } catch (Exception ignored) {
 
         }
-        return moves;
+
+        // Add promoteTo to any promotion moves
+        List<Move> promotedMoves = new ArrayList<>();
+        for (Move m: moves) {
+            int nextY = m.getTo().getY() + direction;
+            if (nextY < 0 || nextY == 8) {
+                // TODO add all of the piece types and then add menu to the GUI
+                promotedMoves.add(m.withPromotion(new Queen(color, player)));
+            } else {
+                promotedMoves.add(m);
+            }
+        }
+        return promotedMoves;
     }
 
     @Override
@@ -122,6 +134,11 @@ public class Pawn extends Piece {
     @Override
     public int getHeuristicValue() {
         return HEURISTIC_VALUE;
+    }
+
+    @Override
+    protected String getName() {
+        return "Pawn";
     }
 
     @Override

--- a/src/com/chess/Game/Pieces/Piece.java
+++ b/src/com/chess/Game/Pieces/Piece.java
@@ -11,8 +11,8 @@ import java.awt.image.BufferedImage;
 import java.util.List;
 
 public abstract class Piece {
-    final NamedColor color;
-    final int player;
+    NamedColor color;
+    int player;
     boolean hasMoved;
     Image rawImage;
 
@@ -20,7 +20,6 @@ public abstract class Piece {
         this.color = color;
         this.player = player;
         this.hasMoved = false;
-
     }
 
     @SuppressWarnings("unused")
@@ -117,9 +116,21 @@ public abstract class Piece {
 
     @Override
     public String toString() {
-        return color.getName().substring(0, 1);
+        return getName();
     }
+
+    protected abstract String getName();
 
     @Override
     public abstract Piece clone();
+
+    public int getPlayer() { return this.player; }
+
+    public void setPlayer(int player) {
+        this.player = player;
+    }
+
+    public void setColor(NamedColor color) {
+        this.color = color;
+    }
 }

--- a/src/com/chess/Game/Pieces/PieceFactory.java
+++ b/src/com/chess/Game/Pieces/PieceFactory.java
@@ -1,0 +1,14 @@
+package com.chess.Game.Pieces;
+
+import com.chess.Settings;
+
+public class PieceFactory {
+    // TODO support all of the piece types
+    public static Piece buildPiece(String name) {
+        Piece queen = new Queen(Settings.p1Color, 1);
+        if (name.equalsIgnoreCase(queen.toString())) {
+            return queen.clone();
+        }
+        return null;
+    }
+}

--- a/src/com/chess/Game/Pieces/Queen.java
+++ b/src/com/chess/Game/Pieces/Queen.java
@@ -38,6 +38,11 @@ public class Queen extends Piece {
     }
 
     @Override
+    protected String getName() {
+        return "Queen";
+    }
+
+    @Override
     public Piece clone() {
         return new Queen(color, player, hasMoved);
     }

--- a/src/com/chess/Game/Pieces/Rook.java
+++ b/src/com/chess/Game/Pieces/Rook.java
@@ -91,6 +91,11 @@ public class Rook extends Piece {
     }
 
     @Override
+    protected String getName() {
+        return "Rook";
+    }
+
+    @Override
     public Piece clone() {
         return new Rook(color, player, hasMoved);
     }


### PR DESCRIPTION
#9 
I added in pawn promotion to the Move and Pawn class but it only supports promotion to Queen so far. Will need to add the others in when I add in the menu in the next PR. I also fixed a bug with the Move to string function not capturing the otherMove field which caused castling to not transfer.